### PR TITLE
chore: bump k8s cluster version from 1.24.13 to 1.24.15

### DIFF
--- a/tests/kind-config.yaml
+++ b/tests/kind-config.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: kubeagi
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.13
+    image: kindest/node:v1.24.15
     kubeadmConfigPatches:
       - |
         kind: InitConfiguration


### PR DESCRIPTION
If we use 1.24.13, in wsl and latest kind (v0.20.0), may have error

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
