### PR TITLE
fix: knowledgebase.spec.fileGroups[*].path use path in versioneddataset

### DIFF
--- a/config/samples/arcadia_v1alpha1_knowledgebase.yaml
+++ b/config/samples/arcadia_v1alpha1_knowledgebase.yaml
@@ -20,4 +20,4 @@ spec:
       name: dataset-playground-v1
       namespace: arcadia
     paths:
-      - dataset/dataset-playground/v1/qa.csv
+      - qa.csv


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

Make the meaning and content of the field `path` in CRD `Knowledgebase` consistent with 
 CRD `Versioneddataset` to avoid ambiguity

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
