### PR TITLE
chore: disable dataprocess pod in example-test

### DIFF
--- a/tests/example-test.sh
+++ b/tests/example-test.sh
@@ -180,7 +180,7 @@ kind load docker-image controller:example-e2e --name=$KindName
 
 info "3. install arcadia"
 kubectl create namespace arcadia
-helm install -narcadia arcadia deploy/charts/arcadia -f tests/deploy-values.yaml --set controller.image=controller:example-e2e --set apiserver.image=controller:example-e2e --wait --timeout $HelmTimeout
+helm install -narcadia arcadia deploy/charts/arcadia -f tests/deploy-values.yaml --set controller.image=controller:example-e2e --set apiserver.image=controller:example-e2e --set dataprocess.enabled=false --wait --timeout $HelmTimeout
 
 info "4. check system datasource arcadia-minio(system datasource)"
 waitCRDStatusReady "Datasource" "arcadia" "arcadia-minio"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

Recently we found that the example test often timeout failure (not 100%), research found that it is the dataprocess pod in the repeated failure to restart, we do not have dataprocess related tests in the example test, therefore, first to disable it to start.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
For #365 

#### Special notes for your reviewer
