### PR TITLE
fix: vectorstore retry too quickly

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 KubeAGI.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// FinalizersChangedPredicate implements an update predicate function on Finalizers change.
+type FinalizersChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements default UpdateEvent filter for validating generation change.
+func (FinalizersChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	return !reflect.DeepEqual(e.ObjectOld.GetFinalizers(), e.ObjectNew.GetFinalizers())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

<table>
<tr>
 <td> user manal
 <td> CR spec update
 <td> CR status update
 <td> CR metadata.generation update
 <td> CR metadata.resourceVersion update
 <td> CR deletionTimestamp update
<tr>
 <td> spec A -> B
 <td> spec.A -> spec.B 
 <td> no change
 <td> metadata.generation +1
 <td> resourceVersion update
 <td>
<tr>
 <td>
 <td> no change
 <td> status.A -> status.B
 <td> no change
 <td> resourceVersion update
 <td>
<tr>
 <td>
 <td> no change
 <td> status.B -> status.B1(time update)
 <td> no change
 <td> resourceVersion update
 <td>
<tr>
 <td>
 <td> no change
 <td> status.B1 -> status.Bx(time update)
 <td> no change
 <td> resourceVersion update
 <td>
<tr>
 <td>
 <td> 
 <td> 
 <td> 
 <td>
 <td>
<tr>
 <td> delete CR
 <td> no change
 <td> no change
 <td> metadata.generation +1
 <td> resourceVersion update
 <td> deletionTimestamp is not empty
<tr>
 <td> 
 <td> no change
 <td> no change
 <td> no change
 <td> resourceVersion update
 <td> deletionTimestamp is not empty
</table>