### PR TITLE
fix: pgvector return nothing when embedding table has vector with dif…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,4 +177,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/tmc/langchaingo => github.com/Abirdcfly/langchaingo v0.0.0-20240110125843-3feb6668f787 // branch arcadia
+replace github.com/tmc/langchaingo => github.com/Abirdcfly/langchaingo v0.0.0-20240124015404-c7798664fdb1 // branch arcadia

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/99designs/gqlgen v0.17.40 h1:/l8JcEVQ93wqIfmH9VS1jsAkwm6eAF1NwQn3N+SDqBY=
 github.com/99designs/gqlgen v0.17.40/go.mod h1:b62q1USk82GYIVjC60h02YguAZLqYZtvWml8KkhJps4=
-github.com/Abirdcfly/langchaingo v0.0.0-20240110125843-3feb6668f787 h1:JNr9Fb9rD0PalCaga2X21KlQ/cVIXnKSy7gUkrrOioo=
-github.com/Abirdcfly/langchaingo v0.0.0-20240110125843-3feb6668f787/go.mod h1:vOFzX91wqTXvirejd6xjPXSmGn8yYKHt/FunAgrOBmI=
+github.com/Abirdcfly/langchaingo v0.0.0-20240124015404-c7798664fdb1 h1:CtCYyn/1c4Dqyk7WSMWUzOAjG1tZSj4JQpAnmhx7b8k=
+github.com/Abirdcfly/langchaingo v0.0.0-20240124015404-c7798664fdb1/go.mod h1:vOFzX91wqTXvirejd6xjPXSmGn8yYKHt/FunAgrOBmI=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=


### PR DESCRIPTION
…ferent dimensions

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

add https://github.com/tmc/langchaingo/pull/548

> Different embedders will have different vector dimensions, and when the embeddings are put into one embedding table, the query will silently error out and return null, which can be circumvented by modifying the sql statement.
> Refer to https://github.com/pgvector/pgvector/issues/428

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
