### PR TITLE
fix: handle some errors in chat when using stream mode

### DIFF
--- a/apiserver/pkg/chat/chat_server.go
+++ b/apiserver/pkg/chat/chat_server.go
@@ -76,6 +76,7 @@ func (cs *ChatServer) Storage() storage.Storage {
 					klog.Infoln("no relational datasource found, use memory storage for chat")
 				}
 				cs.storage = storage.NewMemoryStorage()
+				return
 			}
 			pg, err := datasource.GetPostgreSQLPool(ctx, nil, cs.cli, ds)
 			if err != nil {

--- a/pkg/appruntime/chain/apichain.go
+++ b/pkg/appruntime/chain/apichain.go
@@ -106,7 +106,9 @@ func (l *APIChain) Run(ctx context.Context, cli dynamic.Interface, args map[stri
 	}
 	args["api_docs"] = apiDoc
 	var out string
-	if needStream, ok := args["_need_stream"].(bool); ok && needStream {
+	needStream := false
+	needStream, ok = args["_need_stream"].(bool)
+	if ok && needStream {
 		options = append(options, chains.WithStreamingFunc(stream(args)))
 		out, err = chains.Predict(ctx, l.APIChain, args, options...)
 	} else {
@@ -116,6 +118,7 @@ func (l *APIChain) Run(ctx context.Context, cli dynamic.Interface, args map[stri
 			out, err = chains.Predict(ctx, l.APIChain, args)
 		}
 	}
+	out, err = handleNoErrNoOut(ctx, needStream, out, err, l.APIChain, args, options)
 	klog.FromContext(ctx).V(5).Info("use apichain, blocking out:" + out)
 	if err == nil {
 		args["_answer"] = out

--- a/pkg/appruntime/chain/llmchain.go
+++ b/pkg/appruntime/chain/llmchain.go
@@ -104,7 +104,9 @@ func (l *LLMChain) Run(ctx context.Context, cli dynamic.Interface, args map[stri
 	l.LLMChain = *chain
 
 	var out string
-	if needStream, ok := args["_need_stream"].(bool); ok && needStream {
+	needStream := false
+	needStream, ok = args["_need_stream"].(bool)
+	if ok && needStream {
 		options = append(options, chains.WithStreamingFunc(stream(args)))
 		out, err = chains.Predict(ctx, l.LLMChain, args, options...)
 	} else {
@@ -114,6 +116,7 @@ func (l *LLMChain) Run(ctx context.Context, cli dynamic.Interface, args map[stri
 			out, err = chains.Predict(ctx, l.LLMChain, args)
 		}
 	}
+	out, err = handleNoErrNoOut(ctx, needStream, out, err, l.LLMChain, args, options)
 	klog.FromContext(ctx).V(5).Info("use llmchain, blocking out:" + out)
 	if err == nil {
 		args["_answer"] = out


### PR DESCRIPTION
When using **stream** mode and an error occurs, **fastchat** returns http code 200 and returns an error message in json, but this json is inconsistent with the default format of openai, so it is silently **ignored** by langchaingo, so in this case, we need to re-request the blocking mode to find the correct error message.

fastchat will return like this:
```
data: {"id": "chatcmpl-3Lo28HviQo8949WkJyfFzJ", "model": "7597c2a3-b186-4bac-b2e4-21ff56413f7f", "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": null}]}
data: {"text": "**NETWORK ERROR DUE TO HIGH TRAFFIC. PLEASE REGENERATE OR REFRESH THIS PAGE.**\n\n(\"addmm_impl_cpu_\" not implemented for 'Half')", "error_code": 50001}
data: [DONE]
```
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
