### PR TITLE
feat: added watch on Embedder and VectorStore for KnowledgeBase reconciliation

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"net/http"
 	"net/http/pprof"
@@ -133,7 +132,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-
+	ctx := ctrl.SetupSignalHandler()
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -145,7 +144,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	_, err = clientset.CoreV1().ConfigMaps(utils.GetCurrentNamespace()).Get(context.Background(), config.EnvConfigDefaultValue, metav1.GetOptions{})
+	_, err = clientset.CoreV1().ConfigMaps(utils.GetCurrentNamespace()).Get(ctx, config.EnvConfigDefaultValue, metav1.GetOptions{})
 	if err != nil {
 		setupLog.Error(err, "failed to find required configMap", utils.GetCurrentNamespace(), config.EnvConfigDefaultValue)
 		panic(err)
@@ -213,7 +212,7 @@ func main() {
 		Scheme:                mgr.GetScheme(),
 		HasHandledSuccessPath: make(map[string]bool),
 		ReadyMap:              make(map[string]bool),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KnowledgeBase")
 		os.Exit(1)
 	}
@@ -307,7 +306,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

Details:

- Added watch on Embedder and VectorStore resources for KnowledgeBase reconciliation.
- Updated the SetupWithManager function to include these watches.
- Modified the reconcile function to handle the case when Embedder or VectorStore is not ready.
- Added a condition to check for the readiness of Embedder and VectorStore before marking the KnowledgeBase as ready.
- Added error conditions for cases when Embedder or VectorStore is not ready.

This commit ensures that the KnowledgeBase is properly reconciled when its dependent resources, Embedder and VectorStore, are modified. It also improves the accuracy of the KnowledgeBase's ready status by taking into account the readiness of its dependencies.

when embedder is not ready, knowlegebase should also not ready...

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
