### PR TITLE
fix(application): add isReady check for all nodes in application

### DIFF
--- a/api/base/v1alpha1/condition.go
+++ b/api/base/v1alpha1/condition.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -250,4 +251,14 @@ func (s *ConditionedStatus) ReadyCondition() []Condition {
 		LastSuccessfulTime: metav1.Now(),
 		Message:            "Success",
 	}}
+}
+
+func (s *ConditionedStatus) IsReadyOrGetReadyMessage() (isReady bool, msg string) {
+	if s.IsReady() {
+		return true, ""
+	}
+	for _, cond := range s.Conditions {
+		msg += fmt.Sprintf("%s:%s", cond.Reason, cond.Message)
+	}
+	return false, msg
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -95,6 +95,32 @@ rules:
 - apiGroups:
   - arcadia.kubeagi.k8s.com.cn
   resources:
+  - agents
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - arcadia.kubeagi.k8s.com.cn
+  resources:
+  - agents/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - arcadia.kubeagi.k8s.com.cn
+  resources:
+  - agents/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - arcadia.kubeagi.k8s.com.cn
+  resources:
   - applications
   verbs:
   - create

--- a/controllers/base/application_controller.go
+++ b/controllers/base/application_controller.go
@@ -18,17 +18,39 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	agentv1alpha1 "github.com/kubeagi/arcadia/api/app-node/agent/v1alpha1"
 	chainv1alpha1 "github.com/kubeagi/arcadia/api/app-node/chain/v1alpha1"
+	promptv1alpha1 "github.com/kubeagi/arcadia/api/app-node/prompt/v1alpha1"
+	retrieveralpha1 "github.com/kubeagi/arcadia/api/app-node/retriever/v1alpha1"
 	arcadiav1alpha1 "github.com/kubeagi/arcadia/api/base/v1alpha1"
+	"github.com/kubeagi/arcadia/pkg/appruntime"
+	"github.com/kubeagi/arcadia/pkg/appruntime/base"
+)
+
+const (
+	APIChainIndexKey               = "metadata.apichain"
+	LLMChainIndexKey               = "metadata.llmchain"
+	RetrievalQAChainIndexKey       = "metadata.retrievalqachain"
+	KnowledgebaseIndexKey          = "metadata.knowledgebase"
+	LLMIndexKey                    = "metadata.llm"
+	PromptIndexKey                 = "metadata.prompt"
+	KnowledgebaseRetrieverIndexKey = "metadata.knowledgebaseretriever"
+	AgentIndexKey                  = "metadata.agent"
 )
 
 // ApplicationReconciler reconciles an Application object
@@ -40,6 +62,30 @@ type ApplicationReconciler struct {
 //+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=applications,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=applications/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=applications/finalizers,verbs=update
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=apichains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=apichains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=apichains/finalizers,verbs=update
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=llmchains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=llmchains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=llmchains/finalizers,verbs=update
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=retrievalqachains,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=retrievalqachains/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=chain.arcadia.kubeagi.k8s.com.cn,resources=retrievalqachains/finalizers,verbs=update
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=knowledgebases,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=knowledgebases/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=knowledgebases/finalizers,verbs=update
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=llms,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=llms/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=llms/finalizers,verbs=update
+//+kubebuilder:rbac:groups=prompt.arcadia.kubeagi.k8s.com.cn,resources=prompts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=prompt.arcadia.kubeagi.k8s.com.cn,resources=prompts/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=prompt.arcadia.kubeagi.k8s.com.cn,resources=prompts/finalizers,verbs=update
+//+kubebuilder:rbac:groups=retriever.arcadia.kubeagi.k8s.com.cn,resources=knowledgebaseretrievers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=retriever.arcadia.kubeagi.k8s.com.cn,resources=knowledgebaseretrievers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=retriever.arcadia.kubeagi.k8s.com.cn,resources=knowledgebaseretrievers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=agents,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=agents/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=arcadia.kubeagi.k8s.com.cn,resources=agents/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -68,7 +114,7 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 		log.Info("Adding Finalizer for Application done")
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Check if the Application instance is marked to be deleted, which is
@@ -114,14 +160,14 @@ func (r *ApplicationReconciler) validateNodes(ctx context.Context, log logr.Logg
 	for _, node := range app.Spec.Nodes {
 		if _, ok := nodeName[node.Name]; ok {
 			r.setCondition(app, app.Status.ErrorCondition("node name should be unique")...)
-			return app, ctrl.Result{}, nil
+			return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 		}
 		nodeName[node.Name] = true
 		if node.Ref.Kind == arcadiav1alpha1.InputNode {
 			input++
 			if len(node.NextNodeName) == 0 {
 				r.setCondition(app, app.Status.ErrorCondition("input node needs one or more next nodes")...)
-				return app, ctrl.Result{}, nil
+				return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 			}
 		}
 		if node.Ref.Kind == arcadiav1alpha1.OutputNode {
@@ -129,17 +175,17 @@ func (r *ApplicationReconciler) validateNodes(ctx context.Context, log logr.Logg
 			outputNodeName = node.Name
 			if len(node.NextNodeName) != 0 {
 				r.setCondition(app, app.Status.ErrorCondition("output node should not have next nodes")...)
-				return app, ctrl.Result{}, nil
+				return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 			}
 		}
 	}
 	if input != 1 {
 		r.setCondition(app, app.Status.ErrorCondition("need one input node")...)
-		return app, ctrl.Result{}, nil
+		return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 	}
 	if output != 1 {
 		r.setCondition(app, app.Status.ErrorCondition("need one output node")...)
-		return app, ctrl.Result{}, nil
+		return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 	}
 
 	var toOutput int
@@ -151,12 +197,12 @@ func (r *ApplicationReconciler) validateNodes(ctx context.Context, log logr.Logg
 				group := node.Ref.APIGroup
 				if group == nil {
 					r.setCondition(app, app.Status.ErrorCondition("node should have ref.group setting")...)
-					return app, ctrl.Result{}, nil
+					return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 				}
 				// Only allow chain group or agent node as the ending node
 				if *group != chainv1alpha1.Group && (*group != agentv1alpha1.Group && node.Ref.Kind != "agent") {
 					r.setCondition(app, app.Status.ErrorCondition("ending node should be chain or agent")...)
-					return app, ctrl.Result{}, nil
+					return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 				}
 			}
 			toOutputNodeNext = len(node.NextNodeName)
@@ -164,11 +210,28 @@ func (r *ApplicationReconciler) validateNodes(ctx context.Context, log logr.Logg
 	}
 	if toOutput != 1 {
 		r.setCondition(app, app.Status.ErrorCondition("only one node can output")...)
-		return app, ctrl.Result{}, nil
+		return app, ctrl.Result{RequeueAfter: waitMedium}, nil
 	}
 	if toOutputNodeNext != 1 {
 		r.setCondition(app, app.Status.ErrorCondition("when this node points to output, it can only point to output")...)
-		return app, ctrl.Result{}, nil
+		return app, ctrl.Result{RequeueAfter: waitMedium}, nil
+	}
+
+	ctx = base.SetAppNamespace(ctx, app.Namespace)
+	for _, node := range app.Spec.Nodes {
+		n, err := appruntime.InitNode(ctx, app.Namespace, node.Name, *node.Ref)
+		if err != nil {
+			r.setCondition(app, app.Status.ErrorCondition(fmt.Sprintf("initnode %s failed: %s", node.Name, err.Error()))...)
+			return app, ctrl.Result{RequeueAfter: waitMedium}, nil
+		}
+		if err := n.Init(ctx, r.Client, map[string]any{}); err != nil {
+			r.setCondition(app, app.Status.ErrorCondition(fmt.Sprintf("node %s init failed: %s", node.Name, err.Error()))...)
+			return app, ctrl.Result{RequeueAfter: waitMedium}, nil
+		}
+		if isReady, errMsg := n.Ready(); !isReady {
+			r.setCondition(app, app.Status.ErrorCondition(fmt.Sprintf("node %s init failed: %s", node.Name, errMsg))...)
+			return app, ctrl.Result{RequeueAfter: waitMedium}, nil
+		}
 	}
 
 	r.setCondition(app, app.Status.ReadyCondition()...)
@@ -197,9 +260,6 @@ func (r *ApplicationReconciler) reconcile(ctx context.Context, log logr.Logger, 
 	if !reflect.DeepEqual(app, appRaw) {
 		return app, ctrl.Result{Requeue: true}, r.Patch(ctx, app, client.MergeFrom(appRaw))
 	}
-	if app.Status.IsReady() {
-		return app, ctrl.Result{}, nil
-	}
 	return r.validateNodes(ctx, log, app)
 }
 
@@ -216,10 +276,76 @@ func (r *ApplicationReconciler) patchStatus(ctx context.Context, app *arcadiav1a
 	return r.Client.Status().Patch(ctx, latest, patch, client.FieldOwner("application-controller"))
 }
 
+type Dependency struct {
+	IndexName   string
+	GroupPrefix string
+	Kind        string
+}
+
 // SetupWithManager sets up the controller with the Manager.
-func (r *ApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ApplicationReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	dependencies := []Dependency{
+		{APIChainIndexKey, "chain", "apichain"},
+		{LLMChainIndexKey, "chain", "llmchain"},
+		{RetrievalQAChainIndexKey, "chain", "retrievalqachain"},
+		{KnowledgebaseIndexKey, "", "knowledgebase"},
+		{LLMIndexKey, "", "llm"},
+		{PromptIndexKey, "prompt", "prompt"},
+		{KnowledgebaseRetrieverIndexKey, "retriever", "knowledgebaseretriever"},
+		{AgentIndexKey, "", "agent"},
+	}
+	for _, d := range dependencies {
+		d := d
+		if err := mgr.GetFieldIndexer().IndexField(ctx, &arcadiav1alpha1.Application{}, d.IndexName,
+			func(o client.Object) []string {
+				app, ok := o.(*arcadiav1alpha1.Application)
+				if !ok {
+					return nil
+				}
+				has, ns, name := appruntime.FindNodesHas(app, d.GroupPrefix, d.Kind)
+				if !has {
+					return nil
+				}
+				key := fmt.Sprintf("%s/%s", ns, name)
+				return []string{key}
+			},
+		); err != nil {
+			return err
+		}
+	}
+
+	getEventHandler := func(indexKey string) handler.EventHandler {
+		return handler.EnqueueRequestsFromMapFunc(func(o client.Object) (reqs []reconcile.Request) {
+			var list arcadiav1alpha1.ApplicationList
+			if err := r.List(ctx, &list, client.MatchingFields{indexKey: client.ObjectKeyFromObject(o).String()}); err != nil {
+				ctrl.LoggerFrom(ctx).Error(err, "failed to list Application for"+indexKey)
+				return nil
+			}
+			for _, i := range list.Items {
+				i := i
+				reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&i)})
+			}
+			return reqs
+		})
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&arcadiav1alpha1.Application{}).
+		For(&arcadiav1alpha1.Application{}, builder.WithPredicates(predicate.Funcs{
+			UpdateFunc: func(ue event.UpdateEvent) bool {
+				// Avoid to handle the event that it's not spec update or delete
+				o := ue.ObjectOld.(*arcadiav1alpha1.Application)
+				n := ue.ObjectNew.(*arcadiav1alpha1.Application)
+				return !reflect.DeepEqual(o.Spec, n.Spec) || n.DeletionTimestamp != nil
+			},
+		})).
+		Watches(&source.Kind{Type: &chainv1alpha1.APIChain{}}, getEventHandler(APIChainIndexKey)).
+		Watches(&source.Kind{Type: &chainv1alpha1.LLMChain{}}, getEventHandler(LLMChainIndexKey)).
+		Watches(&source.Kind{Type: &chainv1alpha1.RetrievalQAChain{}}, getEventHandler(RetrievalQAChainIndexKey)).
+		Watches(&source.Kind{Type: &arcadiav1alpha1.KnowledgeBase{}}, getEventHandler(KnowledgebaseIndexKey)).
+		Watches(&source.Kind{Type: &arcadiav1alpha1.LLM{}}, getEventHandler(LLMIndexKey)).
+		Watches(&source.Kind{Type: &promptv1alpha1.Prompt{}}, getEventHandler(PromptIndexKey)).
+		Watches(&source.Kind{Type: &retrieveralpha1.KnowledgeBaseRetriever{}}, getEventHandler(KnowledgebaseRetrieverIndexKey)).
+		Watches(&source.Kind{Type: &agentv1alpha1.Agent{}}, getEventHandler(AgentIndexKey)).
 		Complete(r)
 }
 

--- a/deploy/charts/arcadia/templates/rbac.yaml
+++ b/deploy/charts/arcadia/templates/rbac.yaml
@@ -112,6 +112,32 @@ rules:
 - apiGroups:
   - arcadia.kubeagi.k8s.com.cn
   resources:
+  - agents
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - arcadia.kubeagi.k8s.com.cn
+  resources:
+  - agents/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - arcadia.kubeagi.k8s.com.cn
+  resources:
+  - agents/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - arcadia.kubeagi.k8s.com.cn
+  resources:
   - applications
   verbs:
   - create

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	agentv1alpha1 "github.com/kubeagi/arcadia/api/app-node/agent/v1alpha1"
 	apichain "github.com/kubeagi/arcadia/api/app-node/chain/v1alpha1"
 	apiprompt "github.com/kubeagi/arcadia/api/app-node/prompt/v1alpha1"
 	apiretriever "github.com/kubeagi/arcadia/api/app-node/retriever/v1alpha1"
@@ -69,6 +70,7 @@ func init() {
 	utilruntime.Must(apiretriever.AddToScheme(scheme))
 	utilruntime.Must(evaluationarcadiav1alpha1.AddToScheme(scheme))
 	utilruntime.Must(batchv1.AddToScheme(scheme))
+	utilruntime.Must(agentv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -233,7 +235,7 @@ func main() {
 	if err = (&basecontrollers.ApplicationReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Application")
 		os.Exit(1)
 	}

--- a/pkg/appruntime/base/node.go
+++ b/pkg/appruntime/base/node.go
@@ -37,6 +37,7 @@ type Node interface {
 	SetNextNode(nodes ...Node)
 	GetPrevNode() []Node
 	GetNextNode() []Node
+	Ready() (bool, string)
 	Cleanup()
 }
 
@@ -107,6 +108,10 @@ func (c *BaseNode) Init(_ context.Context, _ client.Client, _ map[string]any) er
 
 func (c *BaseNode) Run(_ context.Context, _ client.Client, _ map[string]any) (map[string]any, error) {
 	return nil, nil
+}
+
+func (c *BaseNode) Ready() (bool, string) {
+	return true, ""
 }
 
 func (c *BaseNode) Cleanup() {

--- a/pkg/appruntime/chain/apichain.go
+++ b/pkg/appruntime/chain/apichain.go
@@ -118,3 +118,7 @@ func (l *APIChain) Run(ctx context.Context, _ client.Client, args map[string]any
 	}
 	return args, fmt.Errorf("apichain run error: %w", err)
 }
+
+func (l *APIChain) Ready() (isReady bool, msg string) {
+	return l.Instance.Status.IsReadyOrGetReadyMessage()
+}

--- a/pkg/appruntime/chain/llmchain.go
+++ b/pkg/appruntime/chain/llmchain.go
@@ -117,3 +117,7 @@ func (l *LLMChain) Run(ctx context.Context, _ client.Client, args map[string]any
 	}
 	return args, fmt.Errorf("llmchain run error: %w", err)
 }
+
+func (l *LLMChain) Ready() (isReady bool, msg string) {
+	return l.Instance.Status.IsReadyOrGetReadyMessage()
+}

--- a/pkg/appruntime/chain/retrievalqachain.go
+++ b/pkg/appruntime/chain/retrievalqachain.go
@@ -134,3 +134,7 @@ func (l *RetrievalQAChain) Run(ctx context.Context, _ client.Client, args map[st
 	}
 	return args, fmt.Errorf("retrievalqachain run error: %w", err)
 }
+
+func (l *RetrievalQAChain) Ready() (isReady bool, msg string) {
+	return l.Instance.Status.IsReadyOrGetReadyMessage()
+}

--- a/pkg/appruntime/knowledgebase/knowledgebase.go
+++ b/pkg/appruntime/knowledgebase/knowledgebase.go
@@ -51,3 +51,7 @@ func (k *Knowledgebase) Init(ctx context.Context, cli client.Client, _ map[strin
 func (k *Knowledgebase) Run(_ context.Context, _ client.Client, args map[string]any) (map[string]any, error) {
 	return args, nil
 }
+
+func (k *Knowledgebase) Ready() (isReady bool, msg string) {
+	return k.Instance.Status.IsReadyOrGetReadyMessage()
+}

--- a/pkg/appruntime/llm/llm.go
+++ b/pkg/appruntime/llm/llm.go
@@ -33,6 +33,7 @@ import (
 type LLM struct {
 	base.BaseNode
 	langchainllms.LLM
+	Instance *v1alpha1.LLM
 }
 
 func NewLLM(baseNode base.BaseNode) *LLM {
@@ -52,6 +53,7 @@ func (z *LLM) Init(ctx context.Context, cli client.Client, _ map[string]any) err
 		return fmt.Errorf("can't convert to langchain llm: %w", err)
 	}
 	z.LLM = llm
+	z.Instance = instance
 	return nil
 }
 
@@ -61,4 +63,8 @@ func (z *LLM) Run(ctx context.Context, _ client.Client, args map[string]any) (ma
 	ns := base.GetAppNamespace(ctx)
 	logger.Info("use llm", "name", z.Ref.Name, "namespace", z.Ref.GetNamespace(ns))
 	return args, nil
+}
+
+func (z *LLM) Ready() (isReady bool, msg string) {
+	return z.Instance.Status.IsReadyOrGetReadyMessage()
 }

--- a/pkg/appruntime/prompt/prompt.go
+++ b/pkg/appruntime/prompt/prompt.go
@@ -76,3 +76,7 @@ func (p *Prompt) Run(ctx context.Context, cli client.Client, args map[string]any
 	args["prompt"] = p
 	return args, nil
 }
+
+func (p *Prompt) Ready() (isReady bool, msg string) {
+	return p.Instance.Status.IsReadyOrGetReadyMessage()
+}

--- a/pkg/appruntime/retriever/knowledgebaseretriever.go
+++ b/pkg/appruntime/retriever/knowledgebaseretriever.go
@@ -160,6 +160,10 @@ func (l *KnowledgeBaseRetriever) Run(ctx context.Context, cli client.Client, arg
 	return args, nil
 }
 
+func (l *KnowledgeBaseRetriever) Ready() (isReady bool, msg string) {
+	return l.Instance.Status.IsReadyOrGetReadyMessage()
+}
+
 func (l *KnowledgeBaseRetriever) Cleanup() {
 	if l.Finish != nil {
 		l.Finish()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

This commit adds `Ready` methods to all nodes in the application.
These methods provide a consistent way to check if a node is ready and to get any error messages that may have occurred during node initialization or execution.

The following changes were made to implement this feature:
- Added `Ready` methods to the `Node` interface.
- Implemented `Ready` methods for all existing node types.
- Updated the application controller to use the `Ready` methods to check if nodes are ready and to handle any errors that may occur.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

based on #696, need merge that first.