### PR TITLE
fix(appruntime): Add `Cleanup()` function to Node interface

### DIFF
--- a/apiserver/pkg/chat/chat_server.go
+++ b/apiserver/pkg/chat/chat_server.go
@@ -142,7 +142,6 @@ func (cs *ChatServer) AppRun(ctx context.Context, req ChatReqBody, respStream ch
 		Query:  req.Query,
 		Answer: "",
 	})
-	ctx = base.SetAppNamespace(ctx, req.AppNamespace)
 	appRun, err := appruntime.NewAppOrGetFromCache(ctx, c, app)
 	if err != nil {
 		return nil, err

--- a/pkg/appruntime/app_runtime.go
+++ b/pkg/appruntime/app_runtime.go
@@ -195,6 +195,7 @@ func (a *Application) Run(ctx context.Context, cli client.Client, respStream cha
 			if out, err = e.Run(ctx, cli, out); err != nil {
 				return Output{}, fmt.Errorf("run node %s: %w", e.Name(), err)
 			}
+			defer e.Cleanup()
 			visited[e.Name()] = true
 		}
 		for _, n := range e.GetNextNode() {

--- a/pkg/appruntime/base/node.go
+++ b/pkg/appruntime/base/node.go
@@ -37,6 +37,7 @@ type Node interface {
 	SetNextNode(nodes ...Node)
 	GetPrevNode() []Node
 	GetNextNode() []Node
+	Cleanup()
 }
 
 func NewBaseNode(appNamespace, nodeName string, ref arcadiav1alpha1.TypedObjectReference) BaseNode {
@@ -106,4 +107,7 @@ func (c *BaseNode) Init(_ context.Context, _ client.Client, _ map[string]any) er
 
 func (c *BaseNode) Run(_ context.Context, _ client.Client, _ map[string]any) (map[string]any, error) {
 	return nil, nil
+}
+
+func (c *BaseNode) Cleanup() {
 }

--- a/pkg/evaluation/evaluation.go
+++ b/pkg/evaluation/evaluation.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/kubeagi/arcadia/api/base/v1alpha1"
 	"github.com/kubeagi/arcadia/pkg/appruntime"
-	"github.com/kubeagi/arcadia/pkg/appruntime/base"
 	pkgdocumentloaders "github.com/kubeagi/arcadia/pkg/documentloaders"
 )
 
@@ -152,7 +151,6 @@ func (eval *RagasDatasetGenerator) Generate(ctx context.Context, csvData io.Read
 		}
 
 		// chat with application
-		ctx = base.SetAppNamespace(ctx, eval.app.Namespace)
 		out, err := eval.app.Run(ctx, eval.cli, nil, appruntime.Input{Question: ragasRow.Question, NeedStream: false, History: memory.NewChatMessageHistory()})
 		if err != nil {
 			klog.V(1).ErrorS(err, "failed to get the answer", "app", eval.app.Name, "namespace", eval.app.Namespace, "question", ragasRow.Question)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

This commit introduces a `Cleanup()` function to the `Node` interface in the `pkg/appruntime/base` package. This function allows nodes to perform cleanup operations when they are finished executing.

Currently the main use is to release the connection to pg, by manually releasing the connection it solves a lot of shenanigans like chat timeout with no content, gpts list 504, etc. (gpts hits are also recorded in pg)

By the way, removing a lot of redundant `base.SetAppNamespace` calls.

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer
