### PR TITLE
fix: hardcode resouce request of gpus to 1 if utilize a existing ray …

### DIFF
--- a/pkg/config/config_type.go
+++ b/pkg/config/config_type.go
@@ -112,7 +112,7 @@ func (rayCluster RayCluster) GetPythonVersion() string {
 	return rayCluster.PythonVersion
 }
 
-// DefaultRayCluster which can be used for vllm worker as local ray cluster
+// DefaultRayCluster which can be used for vllm worker as local ray cluster which can only utilize single node gpus
 func DefaultRayCluster() RayCluster {
 	return RayCluster{
 		Name:          "default",


### PR DESCRIPTION
…cluster

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

Verified on:
1. single node & 2gpus (WITH resource limit of "nvidia.com/gpu = 2")
<img width="804" alt="image" src="https://github.com/kubeagi/arcadia/assets/30621793/805420b4-ba8a-4ee6-98e0-11ddad04405a">

3. two nodes & each have 1 gpu 
  - RAY_CLUSTER_INDEX = 0
  - nvidia.com/gpu = 2
![image](https://github.com/kubeagi/arcadia/assets/30621793/8949f066-876b-40f7-a817-e893c09b0091)

Pod logs:
![image](https://github.com/kubeagi/arcadia/assets/30621793/397ada62-0b50-4e1a-97bc-c36a3ee2d1e2)

