### PR TITLE
feat: add http debug client for llm call

### DIFF
--- a/pkg/langchainwrap/debug_transport.go
+++ b/pkg/langchainwrap/debug_transport.go
@@ -1,0 +1,41 @@
+// inspire by https://github.com/tmc/langchaingo/pull/702
+package langchainwrap
+
+import (
+	"net/http"
+	"net/http/httputil"
+
+	"k8s.io/klog/v2"
+)
+
+// DebugHTTPClient is a http.Client that logs the request and response with full contents.
+var DebugHTTPClient = &http.Client{ //nolint:gochecknoglobals
+	Transport: &logTransport{http.DefaultTransport},
+}
+
+type logTransport struct {
+	Transport http.RoundTripper
+}
+
+// RoundTrip logs the request and response with full contents using httputil.DumpRequest and httputil.DumpResponse.
+func (t *logTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if klog.FromContext(req.Context()).V(5).Enabled() {
+		dump, err := httputil.DumpRequestOut(req, true)
+		if err != nil {
+			return nil, err
+		}
+		klog.FromContext(req.Context()).V(5).Info(string(dump))
+	}
+	resp, err := t.Transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if klog.FromContext(req.Context()).V(5).Enabled() {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, err
+		}
+		klog.FromContext(req.Context()).V(5).Info(string(dump))
+	}
+	return resp, nil
+}

--- a/pkg/langchainwrap/llm.go
+++ b/pkg/langchainwrap/llm.go
@@ -61,7 +61,7 @@ func GetLangchainLLM(ctx context.Context, llm *v1alpha1.LLM, c client.Client, mo
 				}
 				model = models[0]
 			}
-			return openai.New(openai.WithToken(apiKey), openai.WithBaseURL(llm.Get3rdPartyLLMBaseURL()), openai.WithModel(model), openai.WithCallback(log.KLogHandler{LogLevel: 3}))
+			return openai.New(openai.WithToken(apiKey), openai.WithBaseURL(llm.Get3rdPartyLLMBaseURL()), openai.WithModel(model), openai.WithCallback(log.KLogHandler{LogLevel: 3}), openai.WithHTTPClient(DebugHTTPClient))
 		case llms.Gemini:
 			if model == "" {
 				models := llm.GetModelList()
@@ -104,7 +104,7 @@ func GetLangchainLLM(ctx context.Context, llm *v1alpha1.LLM, c client.Client, mo
 		if os.Getenv(GatewayUseExternalURLEnv) == "true" {
 			gatewayURL = gateway.ExternalAPIServer
 		}
-		return openai.New(openai.WithModel(modelName), openai.WithBaseURL(gatewayURL), openai.WithToken("fake"), openai.WithCallback(log.KLogHandler{LogLevel: 3}))
+		return openai.New(openai.WithModel(modelName), openai.WithBaseURL(gatewayURL), openai.WithToken("fake"), openai.WithCallback(log.KLogHandler{LogLevel: 3}), openai.WithHTTPClient(DebugHTTPClient))
 	}
 	return nil, fmt.Errorf("unknown provider type")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeagi/arcadia/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer

log example:
```log
I0410 07:06:48.141884       1 app_runtime.go:197] "try to run node:prompt-node" requestID="d857dcdb2ef313009c8a65aa3481b7ff"
I0410 07:06:48.141897       1 app_runtime.go:197] "try to run node:chain-node" requestID="d857dcdb2ef313009c8a65aa3481b7ff"
I0410 07:06:48.142083       1 log.go:53] "Entering LLM with messages: text: Human: \nnihRole: human" requestID="d857dcdb2ef313009c8a65aa3481b7ff"
I0410 07:06:48.142302       1 debug_transport.go:26] "POST /v1/chat/completions HTTP/1.1\r\nHost: arcadia-fastchat.kubeagi-system.svc.cluster.local:8000\r\nUser-Agent: Go-http-client/1.1\r\nContent-Length: 153\r\nAuthorization: Bearer fake\r\nContent-Type: application/json\r\nAccept-Encoding: gzip\r\n\r\n{\"model\":\"chatglm_lite\",\"messages\":[{\"role\":\"user\",\"content\":[{\"text\":\"Human: \\nnih\",\"type\":\"text\"}]}],\"temperature\":0.7,\"max_tokens\":2048,\"stream\":true}" requestID="d857dcdb2ef313009c8a65aa3481b7ff"
I0410 07:06:48.147648       1 debug_transport.go:35] "HTTP/1.1 400 Bad Request\r\nContent-Length: 160\r\nContent-Type: application/json\r\nDate: Wed, 10 Apr 2024 07:06:47 GMT\r\nServer: uvicorn\r\n\r\n{\"object\":\"error\",\"message\":\"Only cea10419-c146-4ba9-bf80-1db2eabf35b8&&7d862d32-a19d-42b1-b4ef-f2ef64aceeb0 allowed now, your model chatglm_lite\",\"code\":40301}" requestID="d857dcdb2ef313009c8a65aa3481b7ff"
I0410 07:06:48.147725       1 llmchain.go:154] "use llmchain, blocking out:" requestID="d857dcdb2ef313009c8a65aa3481b7ff"
E0410 07:06:48.147828       1 chat.go:116] "error resp, stop the stream" err="run node chain-node: llmchain run error: API returned unexpected status code: 400: " requestID="d857dcdb2ef313009c8a65aa3481b7ff"

```